### PR TITLE
Allow parser options as param

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -11,7 +11,13 @@ module.exports = function (ops) {
     if (file.isStream()) return done(new PluginError('gulp-cheerio', 'Streaming not supported.'));
     var run = typeof ops === 'function' ? ops : ops.run;
     if (run) {
-      var $ = cheerio.load(file.contents.toString());
+      var parserOptions = ops.parserOptions;
+      var $;
+      if (parserOptions) {
+        $ = cheerio.load(file.contents.toString(), parserOptions);
+      } else {
+        $ = cheerio.load(file.contents.toString());
+      }
       if (run.length > 1) {
         run($, next);
       } else {


### PR DESCRIPTION
Unfortunately I couldn't test this one. But I need the parser options very badly. Especially for parsing camel case tags and self closing tags. 

Check for run function and options could be done better. But it's just quick and dirty. 
