### PR TITLE
Update cheerio version to "~0.14.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "sinon-chai": "~2.4.0"
   },
   "dependencies": {
-    "cheerio": "~0.13.0",
+    "cheerio": "~0.14.0",
     "event-stream": "~3.1.0",
     "gulp-util": "~2.2.10"
   }


### PR DESCRIPTION
Cheerio version "~0.14.0" parses self closing tags correctly.
E.g."~0.14.0"^

```
<source src="movie.mp4" type="video/mp4" codecs="avc1.42E01E, mp4a.40.2">
```

"~0.13.0"

```
<source src="movie.mp4" type="video/mp4" codecs="avc1.42E01E, mp4a.40.2"></source>
```
