### PR TITLE
Replace es with through2.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,4 @@
-var es = require('event-stream'),
+var through = require('through2').obj,
     gutil = require('gulp-util'),
     PluginError = gutil.PluginError;
 
@@ -6,7 +6,7 @@ module.exports = function (ops) {
   ops = ops || {};
   var cheerio = ops.cheerio || require('cheerio');
 
-  return es.map(function (file, done) {
+  return through(function (file, encoding, done) {
     if (file.isNull()) return done(null, file);
     if (file.isStream()) return done(new PluginError('gulp-cheerio', 'Streaming not supported.'));
     var run = typeof ops === 'function' ? ops : ops.run;

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "cheerio": "~0.14.0",
-    "event-stream": "~3.1.0",
-    "gulp-util": "~2.2.10"
+    "gulp-util": "~2.2.10",
+    "through2": "^0.6.3"
   }
 }


### PR DESCRIPTION
through2 has a much smaller footprint than event stream; including this instead will make the module faster to download! :smiley:
